### PR TITLE
Clear the serial port buffer when character limit is exceeded

### DIFF
--- a/nonblockingSerial/comms.cpp
+++ b/nonblockingSerial/comms.cpp
@@ -2,6 +2,8 @@
 
 #include "comms.h"
 
+void clearSerialBuffer();
+
 ///////////////////////////////////////////////////////////////////////////////////////
 /// Serial communications
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -59,7 +61,8 @@ void parseMessage(const String& input, Message& msg) {
   // exceeding the limit should produce an invalid command.
   if (input.charAt(input.length() - 1) != LINE_TERMINATOR) {
     msg.isValid = false;
-    msg.errorMsg = "No line terminator found";
+    msg.errorMsg = "Command character limit exceeded without finding a line terminator";
+    clearSerialBuffer();
     return;
   }
   int verbEnd = input.indexOf(' ');
@@ -82,5 +85,14 @@ void parseMessage(const String& input, Message& msg) {
     msg.isValid = false;
     msg.errorMsg = "Unrecognized command: " + input;
     return;
+  }
+}
+
+void clearSerialBuffer() {
+  // Small delay to allow the buffer to fill with any pending characters
+  delay(10);
+
+  while (Serial.available() > 0) {
+    Serial.read();
   }
 }


### PR DESCRIPTION
The current error message that is returned when the serial port character buffer is exceeded is misleading and reports a missing line terminator character. Worse, the rest of the message remains in the hardware buffer and is readout after the error is returned, returning two different error messages.

This clarifies the error message and clears the hardware buffer when the character limit is exceeded.